### PR TITLE
Fix delivery_time bug for trackings

### DIFF
--- a/Aftership-API/src/Tracking.cs
+++ b/Aftership-API/src/Tracking.cs
@@ -385,7 +385,7 @@ namespace AftershipAPI
                 : (string) trackingJSON["courier_tracking_link"];
             _android = new List<String>();
             _ios = new List<String>();
-            _deliveryTime = trackingJSON["delivery_time"].IsNullOrEmpty() ? 0 : (int) trackingJSON["tracked_count"];
+            _deliveryTime = trackingJSON["delivery_time"].IsNullOrEmpty() ? 0 : (int) trackingJSON["delivery_time"];
             _lastUpdatedAt = trackingJSON["last_updated_at"].IsNullOrEmpty()
                 ? DateTime.MinValue
                 : (DateTime) trackingJSON["last_updated_at"];


### PR DESCRIPTION
This PR includes a fix to what seems to be a copy-paste issue causing trackings `delivery_time` to contain the value of `tracked_count` instead.